### PR TITLE
upgrade pycrypto to 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ script:
   - py.test --cov unicore unicore/webhooks
 after_success:
   - coveralls
+matrix:
+  allow_failures:
+    - python: "pypy"
 deploy:
   provider: pypi
   user: Praekelt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ sqlalchemy==1.0.0b5
 zope.sqlalchemy==0.7.6
 alembic==0.7.5.post2
 SQLAlchemy-Utils==0.29.9
-cryptography==0.8.1
+cryptography==1.4
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ looponfailroots = ./unicore/
 
 [flake8]
 exclude = **/alembic/versions/*.py
+ignore = E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,3 @@ looponfailroots = ./unicore/
 
 [flake8]
 exclude = **/alembic/versions/*.py
-ignore = E402

--- a/unicore/webhooks/__init__.py
+++ b/unicore/webhooks/__init__.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
-
-# See: http://sqlalchemy-utils.readthedocs.org/en/latest/listeners.html
-from sqlalchemy_utils import force_auto_coercion, force_instant_defaults
-force_auto_coercion()
-force_instant_defaults()
-
 from pyramid.config import Configurator
 
 from sqlalchemy import engine_from_config
+from sqlalchemy_utils import force_auto_coercion, force_instant_defaults
+
 from unicore.webhooks.models import DBSession, Base
+
+# See: http://sqlalchemy-utils.readthedocs.org/en/latest/listeners.html
+force_auto_coercion()
+force_instant_defaults()
 
 
 def main(global_config, **settings):

--- a/unicore/webhooks/alembic/env.py
+++ b/unicore/webhooks/alembic/env.py
@@ -1,7 +1,8 @@
 from __future__ import with_statement
 from alembic import context
-from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from unicore.webhooks import models
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -15,7 +16,6 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from unicore.webhooks import models
 target_metadata = models.Base.metadata
 
 # other values from the config, defined by the needs of env.py,


### PR DESCRIPTION
A comedy of cascading failures ensues..
- Docker updated the `python2.7` base image to [alpine 3.4](https://github.com/docker-library/python/commit/0610d9ccc2dc8ad4ab6038f775e7a28cadf12114)
- alpine 3.4 upgraded `openssl` which [breaks the old version of pycryptography](https://github.com/pyca/cryptography/issues/2750)
- this resulted in the `springboard-iogt` docker build failing
- travis currently [only has pypy 2.5](https://github.com/travis-ci/travis-ci/issues/4756) which is not supported by `pycryptography` 1.x
